### PR TITLE
Exposed SvgComponent type, added AddElement() method

### DIFF
--- a/core.go
+++ b/core.go
@@ -41,26 +41,30 @@ type Core struct {
 
 func (c *Core) svg() {}
 
-type svgComponent struct {
+type SvgComponent struct {
 	Core
 	elements []Element
 	attrs    []Attribute
 }
 
-func (s *svgComponent) Inner() string {
+func (s *SvgComponent) Inner() string {
 	return ""
 }
 
-func (s *svgComponent) Attributes() []Attribute {
+func (s *SvgComponent) Attributes() []Attribute {
 	return s.attrs
 }
 
-func (s *svgComponent) Tag() string {
+func (s *SvgComponent) Tag() string {
 	return "svg"
 }
 
-func (s *svgComponent) Elements() []Element {
+func (s *SvgComponent) Elements() []Element {
 	return s.elements
+}
+
+func (s *SvgComponent) AddElement(e Element) {
+	s.elements = append(s.elements, e)
 }
 
 func SVG(elementsOrComponents ...Component) Root {
@@ -77,7 +81,7 @@ func SVG(elementsOrComponents ...Component) Root {
 		}
 	}
 
-	return &svgComponent{
+	return &SvgComponent{
 		elements: el,
 		attrs:    attrs,
 	}


### PR DESCRIPTION
In my (experimental) work, I had a need to add elements after the `SvgComponent` was created as I did not know how many elements I needed to add to the image when initializing the image. My solution was to expose the `SvgComponent` type and add an `AddElement()` method.

Example usage:

```
func (p *PageView) renderPieChart() *vecty.HTML {
	paths := p.determinePathsForPieChart()

	image := svg.SVG(
		attr.Width(300),
		attr.Height(300),
		attr.ViewBox(-50, -50, 100, 100),
		attr.Stroke("red"),
	).(*svg.SvgComponent)

	for i, path := range paths {
                c := randomColor()
		image.AddElement(svgelem.Path(attr.Stroke(c), attr.Fill(c), attr.D(path)))
	}

	return elem.Div(
		vecty.Markup(
			vecty.Style("width", "300px"),
			vecty.Style("height", "300px"),
			vecty.Style("display", "inline-flex"),
		),
		svg.Render(
			image,
		),
	)
}
```
